### PR TITLE
Change sideness specification from BOTH to CLIENT

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -17,10 +17,10 @@ The mod comes with a config where you can configure between various algorithms.
     mandatory=true
     versionRange="[36,)"
     ordering="NONE"
-    side="BOTH"
+    side="CLIENT"
 [[dependencies.itemstitchingfix]]
     modId="minecraft"
     mandatory=true
     versionRange="[1.16.4,1.17)"
     ordering="NONE"
-    side="BOTH"
+    side="CLIENT"


### PR DESCRIPTION
Item Stitching Fix is a clientside-only mod which can cause crashes when run on a servers. Changing `side="BOTH"` to `side="CLIENT"` can help Forge to prevent this by not loading it when run on a server.

At the very least, setting it to `CLIENT` would allow [ServerPackCreator](https://github.com/Griefed/ServerPackCreator) to automatically exclude it from any server pack.

Cheers,
Griefed